### PR TITLE
Fix: Decode auth header, to not encode it as b'...' in the HTTP request

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -69,7 +69,7 @@ class AuthServiceProxy(object):
         self.__id_count = 0
         authpair = "%s:%s" % (self.__url.username, self.__url.password)
         authpair = authpair.encode('utf8')
-        self.__auth_header = "Basic %s" % base64.b64encode(authpair)
+        self.__auth_header = "Basic %s" % base64.b64encode(authpair).decode('utf8')
         if self.__url.scheme == 'https':
             self.__conn = httplib.HTTPSConnection(self.__url.hostname, port,
                                                   None, None, False,


### PR DESCRIPTION
Currently, the authpair is encoded as b'...' within the HTTP request, which is obviously wrong. This commit fixes it.
