### PR TITLE
Add optional logging of all RPC communication

### DIFF
--- a/README
+++ b/README
@@ -6,11 +6,13 @@ It includes the following generic improvements:
 - sends protocol 'version', per JSON-RPC 1.1
 - sends proper, incrementing 'id'
 - uses standard Python json lib
+- can optionally log all RPC calls and results
 
 It also includes the following bitcoin-specific details:
 
 - sends Basic HTTP authentication headers
-- parses all JSON numbers that look like floats as Decimal
+- parses all JSON numbers that look like floats as Decimal,
+  and serializes Decimal values to JSON-RPC connections.
 
 Installation:
 
@@ -19,3 +21,28 @@ Installation:
 
 Note: This will only install bitcoinrpc. If you also want to install jsonrpc to preserve 
 backwards compatibility, you have to replace 'bitcoinrpc' with 'jsonrpc' in setup.py and run it again.
+
+Example usage:
+
+    from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+
+    # rpc_user and rpc_password are set in the bitcoin.conf file
+    rpc_connection = AuthServiceProxy("http://%s:%s@127.0.0.1:8332"%(rpc_user, rpc_password))q
+    best_block_hash = rpc_connection.getbestblockhash()
+    print(rpc_connection.getblock(best_block_hash))
+
+Logging all RPC calls to stderr:
+
+    from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+    import logging
+
+    logging.basicConfig()
+    logging.getLogger("BitcoinRPC").setLevel(logging.DEBUG)
+
+    rpc_connection = AuthServiceProxy("http://%s:%s@127.0.0.1:8332"%(rpc_user, rpc_password))
+    print(rpc_connection.getinfo())
+
+Produces output on stderr like:
+
+    DEBUG:BitcoinRPC:-1-> getinfo []
+    DEBUG:BitcoinRPC:<-1- {"connections": 8, ...etc }


### PR DESCRIPTION
More convenient than figuring out how to insert wireshark into the RPC communication path.

Logging the RPC calls and results made can be useful when debugging problems. This uses the standard python logging module; simple usage to trace all RPC calls to stderr:

```
import logging
logging.basicConfig()
logging.getLogger("BitcoinRPC").setLevel(logging.DEBUG)
```

Example logging output:

```
>>> c = AuthServiceProxy("http://u:p@127.0.0.1:18332")
>>> c.getinfo()
DEBUG:BitcoinRPC:-1-> getinfo []
DEBUG:BitcoinRPC:<-1- {"connections": 8, ...etc }

>>> c.setgenerate(True, 2)
DEBUG:BitcoinRPC:-2-> setgenerate [true, 2]
DEBUG:BitcoinRPC:<-2- null

>>> c.setgenerate(True, Decimal('2'))
DEBUG:BitcoinRPC:-3-> setgenerate [true, 2.0]
DEBUG:BitcoinRPC:<-- {"result":null,"error":{"code":-1,"message":"value is type real, expected int"},"id":3}
```

Depends on #29 and #30 
