### PR TITLE
Remove the "strict" parameter of http.client for Python 3.4+ compatability

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -38,6 +38,7 @@ try:
     import http.client as httplib
 except ImportError:
     import httplib
+import sys
 import base64
 import json
 import decimal
@@ -89,12 +90,18 @@ class AuthServiceProxy(object):
             # Callables re-use the connection of the original proxy 
             self.__conn = connection
         elif self.__url.scheme == 'https':
-            self.__conn = httplib.HTTPSConnection(self.__url.hostname, port,
-                                                  None, None, False,
-                                                  timeout)
+            if sys.version_info < (3, 4):
+                self.__conn = httplib.HTTPSConnection(self.__url.hostname, port,
+                                                      None, None, False, timeout)
+            else:
+                self.__conn = httplib.HTTPSConnection(self.__url.hostname, port,
+                                                      None, None, timeout)
         else:
-            self.__conn = httplib.HTTPConnection(self.__url.hostname, port,
-                                                 False, timeout)
+            if sys.version_info < (3, 4):
+                self.__conn = httplib.HTTPConnection(self.__url.hostname, port,
+                                                     False, timeout)
+            else:
+                self.__conn = httplib.HTTPConnection(self.__url.hostname, port, timeout)
 
     def __getattr__(self, name):
         if name.startswith('__') and name.endswith('__'):


### PR DESCRIPTION
The http.client class has obsoleted the parameter 'strict' since Python 3.4, adopt this change in our AuthServiceProxy class to be compatible.

Signed-off-by: Huang Le <4tarhl@gmail.com>