### PR TITLE
Better JSON 2.0 batch support

### DIFF
--- a/README
+++ b/README
@@ -7,6 +7,7 @@ It includes the following generic improvements:
 - sends proper, incrementing 'id'
 - uses standard Python json lib
 - can optionally log all RPC calls and results
+- JSON-2.0 batch support
 
 It also includes the following bitcoin-specific details:
 
@@ -30,6 +31,13 @@ Example usage:
     rpc_connection = AuthServiceProxy("http://%s:%s@127.0.0.1:8332"%(rpc_user, rpc_password))q
     best_block_hash = rpc_connection.getbestblockhash()
     print(rpc_connection.getblock(best_block_hash))
+
+    # batch support : print timestamps of blocks 0 to 99 in 2 RPC round-trips:
+    commands = [ [ "getblockhash", height] for height in range(100) ]
+    block_hashes = rpc_connection.batch_(commands)
+    blocks = rpc_connection.batch_([ [ "getblock", h ] for h in block_hashes ])
+    block_times = [ block["time"] for block in blocks ]
+    print(block_times)
 
 Logging all RPC calls to stderr:
 


### PR DESCRIPTION
Replaces the undocumented, doesn't-really-work `_batch()` call with a `batch_()` method.

Named `batch_` to avoid potential conflicts if a JSON-RPC server uses "batch" as a method name. (not `_batch` because `_foo` is the Python convention for non-public methods).

Builds on #31 
