### PR TITLE
Explicit casting of Decimal to float for python3.3+

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -61,7 +61,7 @@ class JSONRPCException(Exception):
 
 def EncodeDecimal(o):
     if isinstance(o, decimal.Decimal):
-        return round(o, 8)
+        return float(round(o, 8))
     raise TypeError(repr(o) + " is not JSON serializable")
 
 class AuthServiceProxy(object):


### PR DESCRIPTION
In python2.*, rounding a Decimal returns a float, however, in python 3, rounding a Decimal returns a Decimal. This leads to infinite loops in EncodeDecimal when decoding a response containing a float in python3 (tested with python 3.4.0).

>  File "/home/antoine/…/virtualenv/lib/python3.4/site-packages/bitcoinrpc/authproxy.py", line 64, in EncodeDecimal
 >   return round(o, 8)
> RuntimeError: maximum recursion depth exceeded while calling a Python object