### PR TITLE
Generate a more informative exception string; this is useful for debugging applications.

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -55,7 +55,7 @@ log = logging.getLogger("BitcoinRPC")
 
 class JSONRPCException(Exception):
     def __init__(self, rpc_error):
-        Exception.__init__(self)
+        Exception.__init__(self, str(rpc_error))
         self.error = rpc_error
 
 


### PR DESCRIPTION
Generate a more informative exception string; this is useful for debugging applications.

Security note: this opens up another path for external data (in rpc_error) to flow through the application. I think this is safe, assuming that the bitcoind process, and the connection to that process, are trusted. Typically, rpc_error is completely generated by bitcoind, not containing any information from external parties.
