### PR TITLE
parse RPC errors into exception object and provide better output handling

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -57,6 +57,14 @@ class JSONRPCException(Exception):
     def __init__(self, rpc_error):
         Exception.__init__(self)
         self.error = rpc_error
+        self.code = rpc_error['code'] if 'code' in rpc_error else None
+        self.message = rpc_error['message'] if 'message' in rpc_error else None
+
+    def __str__(self):
+        return '%d: %s' % (self.code, self.message)
+
+    def __repr__(self):
+        return '<%s \'%s\'>' % (self.__class__.__name__, self)
 
 
 def EncodeDecimal(o):


### PR DESCRIPTION
parse JSON-RPC error object into `code` and `message` and provide string and object casting. 

example:

```python
try:
    block_hashes = rpc_connection.batch_(commands)
    blocks = rpc_connection.batch_([ [ "getblocks", h ] for h in block_hashes ])
    block_times = [ block["time"] for block in blocks ]
    print(block_times)
except JSONRPCException, e:
    print "Error: %s" % e
    print e.code
    print e.message
````

backwards compatible. 