### PR TITLE
Fix infinite recursion error under Python 3.3.

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -61,7 +61,7 @@ class JSONRPCException(Exception):
 
 def EncodeDecimal(o):
     if isinstance(o, decimal.Decimal):
-        return round(o, 8)
+        return float(round(o, 8))
     raise TypeError(repr(o) + " is not JSON serializable")
 
 class AuthServiceProxy(object):


### PR DESCRIPTION
The EncodeDecimal function is called to make the decimal.Decimal object Json serializable but the round function under Python 3.3 doesn't return a serializable object - it returns another Decimal, so essentially you end up with an infinite loop of trying to repeatedly encode that decimal object.

A simple type cast seems to fix it.