### PR TITLE
Adds parameter for custom ssl contexts

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -80,7 +80,8 @@ def EncodeDecimal(o):
 class AuthServiceProxy(object):
     __id_count = 0
 
-    def __init__(self, service_url, service_name=None, timeout=HTTP_TIMEOUT, connection=None):
+    def __init__(self, service_url, service_name=None, timeout=HTTP_TIMEOUT, 
+                 connection=None, ssl_context=None):
         self.__service_url = service_url
         self.__service_name = service_name
         self.__url = urlparse.urlparse(service_url)
@@ -105,7 +106,7 @@ class AuthServiceProxy(object):
             self.__conn = connection
         elif self.__url.scheme == 'https':
             self.__conn = httplib.HTTPSConnection(self.__url.hostname, port,
-                                                  timeout=timeout)
+                                                  timeout=timeout, context=ssl_context)
         else:
             self.__conn = httplib.HTTPConnection(self.__url.hostname, port,
                                                  timeout=timeout)


### PR DESCRIPTION
This change allows to add custom SSL contexts as a parameter to `AuthServiceProxy`.

Example 1: select a specific protocol version. For example, btcd does not accept anything below TLS 1.2, and auto-selection is broken on many old distributions/versions. See also #35.
Note: TLS 1.2 needs python >= 2.7.9 

```
import ssl;
sslContext = ssl.create_default_context()
sslContext.protocol = ssl.PROTOCOL_TLSv1_2
rpc = AuthServiceProxy("https://username:password@hostname:port", ssl_context=sslContext);
```

Example 2: don't verify ssl certificates
Note: ONLY debug usage, insecure!

```
import ssl;
sslContext = ssl.create_default_context()
sslContext.check_hostname = False
sslContext.verify_mode = ssl.CERT_NONE
rpc = AuthServiceProxy("https://username:password@hostname:port", ssl_context=sslContext);
```
