### PR TITLE
If RPC response doesn't have {error:} throws error

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -134,8 +134,9 @@ class AuthServiceProxy(object):
                              'Content-type': 'application/json'})
 
         response = self._get_response()
-        if response['error'] is not None:
-            raise JSONRPCException(response['error'])
+        if 'error' in response:
+            if response['error'] is not None:
+                raise JSONRPCException(response['error'])
         elif 'result' not in response:
             raise JSONRPCException({
                 'code': -343, 'message': 'missing JSON-RPC result'})


### PR DESCRIPTION
When trying to communicate to a Nodejs RPC server, a Key Error: error would be thrown.