### PR TITLE
EncodeDecimal must return a serializable type

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -74,7 +74,7 @@ class JSONRPCException(Exception):
 
 def EncodeDecimal(o):
     if isinstance(o, decimal.Decimal):
-        return round(o, 8)
+        return float(round(o, 8))
     raise TypeError(repr(o) + " is not JSON serializable")
 
 class AuthServiceProxy(object):


### PR DESCRIPTION
Fixes #54.

Python 2.x's round() automatically converts Decimal types to a float. Python 3's round() returns a rounded Decimal object, leading to infinite recursion as EncodeDecimal is again called (it was passed to json.dumps as default) to convert the Decimal into a serializable type. Explicitly converting to a float will work for both python versions. 