### PR TITLE
Fix default presence of error key in a response.

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -137,8 +137,7 @@ class AuthServiceProxy(object):
         self.__conn.sock.settimeout(self.__timeout)
 
         response = self._get_response()
-        if 'error' in response:
-            if response['error'] is not None:
+        if 'error' in response and response['error'] is not None:
                 raise JSONRPCException(response['error'])
         elif 'result' not in response:
             raise JSONRPCException({


### PR DESCRIPTION
It seems that in some version Bitcoin Core changed their RPC interface slightly, such that
Bitcoin Core 0.10.x works with this library but 0.11.2 does not. This is because the `'error'` key is always present in a response and so a `__call__` always returns `None` instead of `response['result']`.
