### PR TITLE
Bug: returns no result on error=None

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -143,8 +143,8 @@ class AuthServiceProxy(object):
         elif 'result' not in response:
             raise JSONRPCException({
                 'code': -343, 'message': 'missing JSON-RPC result'})
-        else:
-            return response['result']
+        
+        return response['result']
 
     def batch_(self, rpc_calls):
         """Batch RPC call.


### PR DESCRIPTION
Returns neither a result nor raises an exception if `error=None` in response.