### PR TITLE
Handle non-null reponse errors

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -137,9 +137,8 @@ class AuthServiceProxy(object):
         self.__conn.sock.settimeout(self.__timeout)
 
         response = self._get_response()
-        if 'error' in response:
-            if response['error'] is not None:
-                raise JSONRPCException(response['error'])
+        if response.get('error') is not None:
+            raise JSONRPCException(response['error'])
         elif 'result' not in response:
             raise JSONRPCException({
                 'code': -343, 'message': 'missing JSON-RPC result'})


### PR DESCRIPTION
The original code was using nested if statements when it should've used logical and. The outer if was passing but the inner if was failing, so it would skip the outer else and return None. Using dict.get simplifies the condition.