### PR TITLE
We need to handle -32700 "Parse error" correctly

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -165,6 +165,11 @@ class AuthServiceProxy(object):
                              'Content-type': 'application/json'})
         results = []
         responses = self._get_response()
+        if isinstance(responses, (dict,)):
+            if ('error' in responses) and (responses['error'] is not None):
+                raise JSONRPCException(responses['error'])
+            raise JSONRPCException({
+                'code': -32700, 'message': 'Parse error'})
         for response in responses:
             if response['error'] is not None:
                 raise JSONRPCException(response['error'])


### PR DESCRIPTION
Servers that don't support JSON-RPC 2.0 return a single error "Parse error" (single response but not list of responses).

``` python
{u'id': None, u'result': None, u'error': {u'message': u'Parse error', u'code': -32700}}
```

This situation should be handled correctly.

PS: Tested using Namecoin wallet 0.3.80
