### PR TITLE
Add veryfy_ssl option into AuthServiceProxy constructor to allow bypassing cert verification

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -42,6 +42,7 @@ import base64
 import decimal
 import json
 import logging
+import ssl
 try:
     import urllib.parse as urlparse
 except ImportError:
@@ -80,7 +81,7 @@ def EncodeDecimal(o):
 class AuthServiceProxy(object):
     __id_count = 0
 
-    def __init__(self, service_url, service_name=None, timeout=HTTP_TIMEOUT, connection=None):
+    def __init__(self, service_url, service_name=None, timeout=HTTP_TIMEOUT, connection=None, verify_ssl=True):
         self.__service_url = service_url
         self.__service_name = service_name
         self.__url = urlparse.urlparse(service_url)
@@ -106,8 +107,13 @@ class AuthServiceProxy(object):
             # Callables re-use the connection of the original proxy
             self.__conn = connection
         elif self.__url.scheme == 'https':
-            self.__conn = httplib.HTTPSConnection(self.__url.hostname, port,
-                                                  timeout=timeout)
+            if verify_ssl:
+                self.__conn = httplib.HTTPSConnection(
+                    self.__url.hostname, port, timeout=timeout)
+            else:
+                self.__conn = httplib.HTTPSConnection(
+                    self.__url.hostname, port, timeout=timeout,
+                    context=ssl._create_unverified_context())
         else:
             self.__conn = httplib.HTTPConnection(self.__url.hostname, port,
                                                  timeout=timeout)


### PR DESCRIPTION
In v1.0, we can create connection with `ssl._create_unverified_context` then pass it into constructor on `AuthServiceProxy` instantiation to allow unverified SSL. This PR proposes an intuitive option to achieve this. 