### PR TITLE
Added support for electrum rpc

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -187,7 +187,7 @@ class AuthServiceProxy(object):
                 'code': -342, 'message': 'missing HTTP response from server'})
 
         content_type = http_response.getheader('Content-Type')
-        if content_type != 'application/json':
+        if content_type != 'application/json' and content_type != 'application/json-rpc':
             raise JSONRPCException({
                 'code': -342, 'message': 'non-JSON HTTP response with \'%i %s\' from server' % (http_response.status, http_response.reason)})
 


### PR DESCRIPTION
Electrum's response content-type is different, this just edits the line where an error was raised everytime a request was made so it can work normally.