### PR TITLE
Request exceptions catched to prevent entering in a broken connection state

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -130,11 +130,15 @@ class AuthServiceProxy(object):
                                'method': self.__service_name,
                                'params': args,
                                'id': AuthServiceProxy.__id_count}, default=EncodeDecimal)
-        self.__conn.request('POST', self.__url.path, postdata,
-                            {'Host': self.__url.hostname,
-                             'User-Agent': USER_AGENT,
-                             'Authorization': self.__auth_header,
-                             'Content-type': 'application/json'})
+        try:
+            self.__conn.request('POST', self.__url.path, postdata,
+                                {'Host': self.__url.hostname,
+                                'User-Agent': USER_AGENT,
+                                'Authorization': self.__auth_header,
+                                'Content-type': 'application/json'})
+        except Exception as e:
+            self.__conn.close()
+            raise e
         self.__conn.sock.settimeout(self.__timeout)
 
         response = self._get_response()
@@ -159,11 +163,15 @@ class AuthServiceProxy(object):
 
         postdata = json.dumps(batch_data, default=EncodeDecimal)
         log.debug("--> "+postdata)
-        self.__conn.request('POST', self.__url.path, postdata,
-                            {'Host': self.__url.hostname,
-                             'User-Agent': USER_AGENT,
-                             'Authorization': self.__auth_header,
-                             'Content-type': 'application/json'})
+        try:
+            self.__conn.request('POST', self.__url.path, postdata,
+                                {'Host': self.__url.hostname,
+                                'User-Agent': USER_AGENT,
+                                'Authorization': self.__auth_header,
+                                'Content-type': 'application/json'})
+        except Exception as e:
+            self.__conn.close()
+            raise e
         results = []
         responses = self._get_response()
         if isinstance(responses, (dict,)):


### PR DESCRIPTION
Sometimes, when you make a request, it can raise httplib Exceptions like BadStatusLine.
When this happens, the line to get the response is not called, and connection enter in a broken state.

If you make successive JSON calls, the object will always return "httplib.CannotSendRequest" error.

So, the connection is closed after the exception raised to prevent this kind of behavior.