### PR TITLE
Support '/' character in HTTP password

### DIFF
--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -91,6 +91,13 @@ class AuthServiceProxy(object):
             port = self.__url.port
         (user, passwd) = (self.__url.username, self.__url.password)
         try:
+            # This will not work with python2, try ignoring. Nothing bad
+            # will happen unless there are special quuoted characters in
+            # HTTP password.
+            passwd = urlparse.unquote(passwd)
+        except AttributeError:
+            pass
+        try:
             user = user.encode('utf8')
         except AttributeError:
             pass


### PR DESCRIPTION
It should be callers responsibility to properly encode URL.

This will unquote any `%..`, but is especially important for `/`, due to how `urllib.parse.urlparse()` works.

```
>>> import urllib.parse as urlparse
>>> url = urlparse.urlparse('http://user:pwdwith/slash@127.0.0.1:8332')
>>> print (url.username, url.password, url.hostname, url.port)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.8/urllib/parse.py", line 177, in port
    raise ValueError(message) from None
ValueError: Port could not be cast to integer value as 'pwdwith'
>>> from requests.utils import quote
>>> url = urlparse.urlparse('http://user:{}@127.0.0.1:8332'.format(quote('pwdwith/slash', safe='')))
>>> print (url.username, url.password, url.hostname, url.port)
user pwdwith%2Fslash 127.0.0.1 8332
>>> print (url.username, urlparse.unquote(url.password), url.hostname, url.port)
user pwdwith/slash 127.0.0.1 8332
```

Will not work with Python2 as `urlparse` module does no thave `unquote()`. But Python2 is long time EOL and should not be used anyway.